### PR TITLE
Add missing #include <QKeyEvent>, necessary for Qt 5.14.2

### DIFF
--- a/src/SelectionLayer.cpp
+++ b/src/SelectionLayer.cpp
@@ -18,6 +18,7 @@
 #include <QDebug>
 #include <QPainter>
 #include <QTextDocument>
+#include <QKeyEvent>
 
 const QColor SelectionLayer::toolColorForeground	= QColor(255, 174, 66, 200);
 const QColor SelectionLayer::toolColorBackground	= QColor(255, 174, 66, 150);

--- a/src/ViewerWidget.cpp
+++ b/src/ViewerWidget.cpp
@@ -15,6 +15,7 @@
 #include <QOpenGLDebugLogger>
 #include <QPainter>
 #include <QMessageBox>
+#include <QKeyEvent>
 
 ViewerWidget::ViewerWidget(ImageViewerPlugin* imageViewerPlugin) :
 	QOpenGLWidget(imageViewerPlugin),


### PR DESCRIPTION
Fixes compilation errors from Visual C++ 2019, including:

> ViewerWidget.cpp(81,49): error C2440: 'static_cast': cannot convert from 'QEvent *' to 'QKeyEvent *'
> ViewerWidget.cpp(81,20): message : Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
  ...
> SelectionLayer.cpp(640,11): error C3536: 'keyEvent': cannot be used before it is initialized