### PR TITLE
Make use of the improved point data visit function from hdps/core#81

### DIFF
--- a/src/PointsLayer.cpp
+++ b/src/PointsLayer.cpp
@@ -1264,7 +1264,7 @@ void PointsLayer::computeStackChannel(Channel<float>* channel, const ChannelInde
 {
 	channel->fill(0.0f);
 
-	_pointsDataset->visitData([this, channel](auto pointData) {
+	_pointsDataset->visitSourceData([this, channel](auto pointData) {
 		const auto dimensionId = channel->dimensionId();
 
 		for (auto pointView : pointData) {


### PR DESCRIPTION
This pull request changes parts of the image viewer (`computeSequenceChannel()` + `computeStackChannel()` + `computeMaskChannel()`) where point data is being queryied. It uses improved visit function(s) from hdps/core#81.

