### PR TITLE
Add hdps::fromStdVector() to fix errors about missing Qt constructors

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm> // For std::copy.
+#include <iterator> // For std::back_inserter.
 #include <vector>
 #include <map>
 #include <type_traits>
@@ -200,4 +202,20 @@ inline QString colorSpaceName(const ColorSpace& colorSpace)
 	}
 
 	return "";
+}
+
+namespace hdps
+{
+	/**
+	 * Creates a container of the specified type, and copies the elements from the
+	 * specified `std::vector` into the created container.
+	 */
+	template <typename ContainerType, typename ValueType>
+	auto fromStdVector(const std::vector<ValueType>& stdVector)
+	{
+		ContainerType result;
+		result.reserve(static_cast<int>(stdVector.size()));
+		std::copy(stdVector.cbegin(), stdVector.cend(), std::back_inserter(result));
+		return result;
+	}
 }

--- a/src/ImageViewerPlugin.cpp
+++ b/src/ImageViewerPlugin.cpp
@@ -74,7 +74,7 @@ void ImageViewerPlugin::selectionChanged(const QString dataset)
 
 	for (auto hit : hits) {
 		auto selection = dynamic_cast<Points&>(_core->requestSelection(dataset));
-		const auto indices = QVector<uint>(selection.indices.begin(), selection.indices.end());
+		const auto indices = hdps::fromStdVector<QVector<uint>>(selection.indices);
 		_layersModel.setData(hit.siblingAtColumn(ult(Layer::Column::Selection)), QVariant::fromValue(indices));
 	}
 

--- a/src/PointsLayer.cpp
+++ b/src/PointsLayer.cpp
@@ -56,7 +56,7 @@ void PointsLayer::init()
 	setUseConstantColor(false);
 	setChannelEnabled(ChannelIndex::Channel1, true);
 
-	auto dimensionNames = QStringList(_pointsDataset->getDimensionNames().begin(), _pointsDataset->getDimensionNames().end());
+	auto dimensionNames = hdps::fromStdVector<QStringList>(_pointsDataset->getDimensionNames());
 
 	if (dimensionNames.isEmpty()) {
 		for (int dimensionIndex = 0; dimensionIndex < noDimensions(Qt::EditRole).toInt(); dimensionIndex++) {
@@ -71,8 +71,7 @@ void PointsLayer::init()
 	auto selection = dynamic_cast<Points*>(&imageViewerPlugin->core()->requestSelection(pointsDataName));
 
 	if (selection) {
-		const auto indices = selection->indices;
-		setSelection(QVector<std::uint32_t>(indices.begin(), indices.end()));
+		setSelection(hdps::fromStdVector<QVector<std::uint32_t>>(selection->indices));
 	}
 
 	computeChannel(ChannelIndex::Mask);


### PR DESCRIPTION
Added `hdps::fromStdVector(const std::vector<ValueType>&)`, fixing three errors on the CI, which were triggered by the fact that the CI still uses an old version of Qt (5.12.4).

From xcode10.3:

> ImageViewerPlugin.cpp:77:24: error: no matching constructor for initialization of 'QVector<uint>'

From GCC9:

> PointsLayer.cpp:59:122: error: no matching function for call to ‘QStringList::QStringList(std::vector<QString>::const_iterator, std::vector<QString>::const_iterator)’

https://travis-ci.com/github/bldrvnlw/conan-ImageViewerPlugin/jobs/367085106#L8362

https://travis-ci.com/github/bldrvnlw/conan-ImageViewerPlugin/jobs/368253954#L1620