### PR TITLE
Add unity build option 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.12.0)
 
+option(MV_UNITY_BUILD "Combine target source files into batches for faster compilation" OFF)
+
 # -----------------------------------------------------------------------------
 # ImageViewer Plugin
 # -----------------------------------------------------------------------------
@@ -167,9 +169,6 @@ QT6_ADD_RESOURCES(RESOURCE_FILES ${QRC})
 # -----------------------------------------------------------------------------
 add_library(${PROJECT} SHARED ${SOURCES} ${UIS} ${SHADERS} ${AUX} ${RESOURCE_FILES})
 
-qt_wrap_cpp(IMAGEVIEWER_MOC ${PLUGIN_MOC_HEADERS} TARGET ${PROJECT})
-target_sources(${PROJECT} PRIVATE ${IMAGEVIEWER_MOC})
-
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
@@ -181,6 +180,10 @@ target_include_directories(${PROJECT} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION
 # Target properties
 # -----------------------------------------------------------------------------
 target_compile_features(${PROJECT} PRIVATE cxx_std_17)
+
+if(MV_UNITY_BUILD)
+    set_target_properties(${PROJECT} PROPERTIES UNITY_BUILD ON)
+endif()
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/conanfile.py
+++ b/conanfile.py
@@ -104,6 +104,9 @@ class ImageViewerPluginConan(ConanFile):
         # Give the installation directory to CMake
         tc.variables["MV_INSTALL_DIR"] = self.install_dir
         
+        # Set some build options
+        tc.variables["MV_UNITY_BUILD"] = "ON"
+        
         tc.generate()
 
     def _configure_cmake(self):


### PR DESCRIPTION
Adds optional [unity build](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html): `OFF` by default, except on CI where it's `ON`.