### PR TITLE
Restore key bindings for additive and subtractive pixel selections

### DIFF
--- a/src/ImageViewerWidget.cpp
+++ b/src/ImageViewerWidget.cpp
@@ -42,6 +42,7 @@ ImageViewerWidget::ImageViewerWidget(ImageViewerPlugin& imageViewerPlugin) :
     setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     //setFocusPolicy(Qt::StrongFocus);
     setMouseTracking(true);
+    setFocusPolicy(Qt::StrongFocus);
 
     // Configure pixel selection tool
     _pixelSelectionTool.setEnabled(false);

--- a/src/ImageViewerWidget.h
+++ b/src/ImageViewerWidget.h
@@ -164,6 +164,6 @@ protected:
     std::int32_t                            _keys;                      /** Currently pressed keyboard keys */
     QVector<QPoint>                         _mousePositions;            /** Recorded mouse positions */
     int                                     _mouseButtons;              /** State of the left, middle and right mouse buttons */
-    LayersRenderer                                _renderer;                  /** Layers OpenGL renderer */
+    LayersRenderer                          _renderer;                  /** Layers OpenGL renderer */
     InteractionMode                         _interactionMode;           /** Interaction mode e.g. navigation and layer editing */
 };


### PR DESCRIPTION
Sets the focus policy of the `ImageViewerWidget` to `Qt::StrongFocus`, thus it will receive key events and it can properly engage/disengage `additive`/`subtractive` pixel selection.