### PR TITLE
Update new image data

### DIFF
--- a/src/ConvertToImagesDatasetDialog.cpp
+++ b/src/ConvertToImagesDatasetDialog.cpp
@@ -95,6 +95,8 @@ ConvertToImagesDatasetDialog::ConvertToImagesDatasetDialog(ImageViewerPlugin& im
         images->setNumberOfComponentsPerPixel(1);
         images->setLinkedDataFlag(DatasetImpl::LinkedDataFlag::Receive, _useLinkedDataAction.isChecked());
 
+        events().notifyDatasetDataChanged(images);
+
         _targetImagesDataset = images;
 
         accept();

--- a/src/SubsetAction.cpp
+++ b/src/SubsetAction.cpp
@@ -67,6 +67,8 @@ void SubsetAction::initialize(ImageViewerPlugin* imageViewerPlugin)
             imagesSubset->setNumberOfImages(images->getNumberOfImages());
             imagesSubset->setImageSize(images->getImageSize());
             imagesSubset->setNumberOfComponentsPerPixel(images->getNumberOfComponentsPerPixel());
+
+            events().notifyDatasetDataChanged(imagesSubset);
         }
         catch (std::exception& e)
         {

--- a/src/SubsetAction.cpp
+++ b/src/SubsetAction.cpp
@@ -57,7 +57,7 @@ void SubsetAction::initialize(ImageViewerPlugin* imageViewerPlugin)
                 return;
 
             auto points = Dataset<Points>(layer->getSourceDataset());
-            auto images = layer->getImagesDataset();
+            const auto& images = layer->getImagesDataset();
 
             auto subset = points->createSubsetFromSelection(_nameAction.getString(), points);
 


### PR DESCRIPTION
The core needs to be notified when adjusting image meta data.

Currently, when drag&dropping a HSNE refinement, no meta data is shown:
![Untitled](https://github.com/user-attachments/assets/3fd240eb-963d-4c52-8c61-e94d596c6edc)

After this PR:
![Untitled-1](https://github.com/user-attachments/assets/f775c6c0-a463-4a5d-8521-af4e5d3a97a1)

Fixes #134