### PR TITLE
Add option to restrict data range to color space range 

### DIFF
--- a/src/ImageSettingsAction.cpp
+++ b/src/ImageSettingsAction.cpp
@@ -76,8 +76,7 @@ ImageSettingsAction::ImageSettingsAction(QObject* parent, const QString& title) 
         if (_fixChannelRangesToColorSpaceAction.isChecked()) {
 
             // only set color space range for RGB, HSL and LAB
-            switch (static_cast<ColorSpaceType>(_colorSpaceAction.getCurrentIndex()))
-            {
+            switch (static_cast<ColorSpaceType>(_colorSpaceAction.getCurrentIndex())) {
 	            case ColorSpaceType::RGB: {
 	                _scalarChannel1Action.setColorSpaceRange(true, 0, 255); // red
 	                _scalarChannel2Action.setColorSpaceRange(true, 0, 255); // green

--- a/src/ImageSettingsAction.cpp
+++ b/src/ImageSettingsAction.cpp
@@ -24,7 +24,7 @@ ImageSettingsAction::ImageSettingsAction(QObject* parent, const QString& title) 
     _colorMap2DAction(this, "2D Color map", "example_a"),
     _interpolationTypeAction(this, "Interpolate", interpolationTypes.values(), "Bilinear"),
     _useConstantColorAction(this, "Use constant color", false),
-    _fixChannelRangesToColorSpace(this, "Set channel ranges to color space", false),
+    _fixChannelRangesToColorSpaceAction(this, "Set channel ranges to color space", false),
     _constantColorAction(this, "Constant color", QColor(Qt::white)),
     _updateSelectionTimer(),
     _updateScalarDataTimer()
@@ -39,7 +39,7 @@ ImageSettingsAction::ImageSettingsAction(QObject* parent, const QString& title) 
     addAction(&_colorMap2DAction);
     addAction(&_interpolationTypeAction);
     addAction(&_useConstantColorAction);
-    addAction(&_fixChannelRangesToColorSpace);
+    addAction(&_fixChannelRangesToColorSpaceAction);
     addAction(&_constantColorAction);
 
     _subsampleFactorAction.setVisible(false);
@@ -54,7 +54,7 @@ ImageSettingsAction::ImageSettingsAction(QObject* parent, const QString& title) 
     _colorMap2DAction.setToolTip("Image two-dimensional color map");
     _interpolationTypeAction.setToolTip("The type of two-dimensional image interpolation used");
     _useConstantColorAction.setToolTip("Use constant color to shade the image");
-    _fixChannelRangesToColorSpace.setToolTip("In this mode, data ranges are ignored and the channel ranges are set to the current color space range (RGB, HSL or LAB)");
+    _fixChannelRangesToColorSpaceAction.setToolTip("In this mode, data ranges are ignored and the channel ranges are set to the current color space range (RGB, HSL or LAB)");
     _constantColorAction.setToolTip("Constant color");
 
     _opacityAction.setSuffix("%");
@@ -72,10 +72,10 @@ ImageSettingsAction::ImageSettingsAction(QObject* parent, const QString& title) 
 
     connect(&_useConstantColorAction, &ToggleAction::toggled, this, useConstantColorToggled);
 
-    connect(&_fixChannelRangesToColorSpace, &ToggleAction::toggled, this, [this](bool toggled) {
+    connect(&_fixChannelRangesToColorSpaceAction, &ToggleAction::toggled, this, [this](bool toggled) {
 
         // Set color space range
-        if (_fixChannelRangesToColorSpace.isChecked())
+        if (_fixChannelRangesToColorSpaceAction.isChecked())
         {
             // only set color space range for RGB, HSL and LAB
             switch (static_cast<ColorSpaceType>(_colorSpaceAction.getCurrentIndex()))
@@ -352,8 +352,8 @@ void ImageSettingsAction::colorSpaceChanged()
             _colorMap1DAction.setEnabled(isClusterType ? false : (!_useConstantColorAction.isChecked()));
             _colorMap2DAction.setEnabled(false);
 
-            _fixChannelRangesToColorSpace.setChecked(false);
-            _fixChannelRangesToColorSpace.setEnabled(false);
+            _fixChannelRangesToColorSpaceAction.setChecked(false);
+            _fixChannelRangesToColorSpaceAction.setEnabled(false);
 
             break;
         }
@@ -371,8 +371,8 @@ void ImageSettingsAction::colorSpaceChanged()
             _colorMap1DAction.setEnabled(false);
             _colorMap2DAction.setEnabled(!_useConstantColorAction.isChecked());
 
-            _fixChannelRangesToColorSpace.setChecked(false);
-            _fixChannelRangesToColorSpace.setEnabled(false);
+            _fixChannelRangesToColorSpaceAction.setChecked(false);
+            _fixChannelRangesToColorSpaceAction.setEnabled(false);
 
             break;
         }
@@ -390,7 +390,7 @@ void ImageSettingsAction::colorSpaceChanged()
             _colorMap1DAction.setEnabled(false);
             _colorMap2DAction.setEnabled(false);
 
-            _fixChannelRangesToColorSpace.setEnabled(true);
+            _fixChannelRangesToColorSpaceAction.setEnabled(true);
 
             break;
         }
@@ -408,7 +408,7 @@ void ImageSettingsAction::colorSpaceChanged()
             _colorMap1DAction.setEnabled(false);
             _colorMap2DAction.setEnabled(false);
 
-            _fixChannelRangesToColorSpace.setEnabled(true);
+            _fixChannelRangesToColorSpaceAction.setEnabled(true);
 
             break;
         }
@@ -426,7 +426,7 @@ void ImageSettingsAction::colorSpaceChanged()
             _colorMap1DAction.setEnabled(false);
             _colorMap2DAction.setEnabled(false);
 
-            _fixChannelRangesToColorSpace.setEnabled(true);
+            _fixChannelRangesToColorSpaceAction.setEnabled(true);
 
             break;
         }

--- a/src/ImageSettingsAction.cpp
+++ b/src/ImageSettingsAction.cpp
@@ -352,6 +352,9 @@ void ImageSettingsAction::colorSpaceChanged()
             _colorMap1DAction.setEnabled(isClusterType ? false : (!_useConstantColorAction.isChecked()));
             _colorMap2DAction.setEnabled(false);
 
+            _fixChannelRangesToColorSpace.setChecked(false);
+            _fixChannelRangesToColorSpace.setEnabled(false);
+
             break;
         }
 
@@ -367,6 +370,9 @@ void ImageSettingsAction::colorSpaceChanged()
 
             _colorMap1DAction.setEnabled(false);
             _colorMap2DAction.setEnabled(!_useConstantColorAction.isChecked());
+
+            _fixChannelRangesToColorSpace.setChecked(false);
+            _fixChannelRangesToColorSpace.setEnabled(false);
 
             break;
         }
@@ -384,6 +390,8 @@ void ImageSettingsAction::colorSpaceChanged()
             _colorMap1DAction.setEnabled(false);
             _colorMap2DAction.setEnabled(false);
 
+            _fixChannelRangesToColorSpace.setEnabled(true);
+
             break;
         }
 
@@ -400,6 +408,8 @@ void ImageSettingsAction::colorSpaceChanged()
             _colorMap1DAction.setEnabled(false);
             _colorMap2DAction.setEnabled(false);
 
+            _fixChannelRangesToColorSpace.setEnabled(true);
+
             break;
         }
 
@@ -415,6 +425,8 @@ void ImageSettingsAction::colorSpaceChanged()
 
             _colorMap1DAction.setEnabled(false);
             _colorMap2DAction.setEnabled(false);
+
+            _fixChannelRangesToColorSpace.setEnabled(true);
 
             break;
         }

--- a/src/ImageSettingsAction.cpp
+++ b/src/ImageSettingsAction.cpp
@@ -25,9 +25,7 @@ ImageSettingsAction::ImageSettingsAction(QObject* parent, const QString& title) 
     _interpolationTypeAction(this, "Interpolate", interpolationTypes.values(), "Bilinear"),
     _useConstantColorAction(this, "Use constant color", false),
     _fixChannelRangesToColorSpaceAction(this, "Set channel ranges to color space", false),
-    _constantColorAction(this, "Constant color", QColor(Qt::white)),
-    _updateSelectionTimer(),
-    _updateScalarDataTimer()
+    _constantColorAction(this, "Constant color", QColor(Qt::white))
 {
     addAction(&_opacityAction);
     addAction(&_subsampleFactorAction);
@@ -75,41 +73,38 @@ ImageSettingsAction::ImageSettingsAction(QObject* parent, const QString& title) 
     connect(&_fixChannelRangesToColorSpaceAction, &ToggleAction::toggled, this, [this](bool toggled) {
 
         // Set color space range
-        if (_fixChannelRangesToColorSpaceAction.isChecked())
-        {
+        if (_fixChannelRangesToColorSpaceAction.isChecked()) {
+
             // only set color space range for RGB, HSL and LAB
             switch (static_cast<ColorSpaceType>(_colorSpaceAction.getCurrentIndex()))
             {
-            case ColorSpaceType::RGB:
-            {
-                _scalarChannel1Action.setColorSpaceRange(true, 0, 255); // red
-                _scalarChannel2Action.setColorSpaceRange(true, 0, 255); // green
-                _scalarChannel3Action.setColorSpaceRange(true, 0, 255); // blue
-                break;
-            }
+	            case ColorSpaceType::RGB: {
+	                _scalarChannel1Action.setColorSpaceRange(true, 0, 255); // red
+	                _scalarChannel2Action.setColorSpaceRange(true, 0, 255); // green
+	                _scalarChannel3Action.setColorSpaceRange(true, 0, 255); // blue
+	                break;
+	            }
 
-            case ColorSpaceType::HSL:
-            {
-                _scalarChannel1Action.setColorSpaceRange(true, 0, 360); // hue
-                _scalarChannel2Action.setColorSpaceRange(true, 0, 1);   // saturation
-                _scalarChannel3Action.setColorSpaceRange(true, 0, 1);   // value
-                break;
-            }
+	            case ColorSpaceType::HSL: {
+	                _scalarChannel1Action.setColorSpaceRange(true, 0, 360); // hue
+	                _scalarChannel2Action.setColorSpaceRange(true, 0, 1);   // saturation
+	                _scalarChannel3Action.setColorSpaceRange(true, 0, 1);   // value
+	                break;
+	            }
 
-            case ColorSpaceType::LAB:
-            {
-                _scalarChannel1Action.setColorSpaceRange(true, 0, 100);     // L
-                _scalarChannel2Action.setColorSpaceRange(true, -128, 127);  // A
-                _scalarChannel3Action.setColorSpaceRange(true, -128, 127);  // B
-                break;
-            }
-            default:
-            {
-                _scalarChannel1Action.setColorSpaceRange(false);
-                _scalarChannel2Action.setColorSpaceRange(false);
-                _scalarChannel3Action.setColorSpaceRange(false);
-                break;
-            }
+	            case ColorSpaceType::LAB: {
+	                _scalarChannel1Action.setColorSpaceRange(true, 0, 100);     // L
+	                _scalarChannel2Action.setColorSpaceRange(true, -128, 127);  // A
+	                _scalarChannel3Action.setColorSpaceRange(true, -128, 127);  // B
+	                break;
+	            }
+
+	            default: {
+	                _scalarChannel1Action.setColorSpaceRange(false);
+	                _scalarChannel2Action.setColorSpaceRange(false);
+	                _scalarChannel3Action.setColorSpaceRange(false);
+	                break;
+	            }
 
             } // switch
         }

--- a/src/ImageSettingsAction.cpp
+++ b/src/ImageSettingsAction.cpp
@@ -283,7 +283,7 @@ const std::uint32_t ImageSettingsAction::getNumberOfActiveScalarChannels() const
 QImage ImageSettingsAction::getColorMapImage() const
 {
     if (_layer->getSourceDataset()->getDataType() == ClusterType) {
-        auto clusters = Dataset<Clusters>(_layer->getSourceDataset())->getClusters();
+        const auto& clusters = Dataset<Clusters>(_layer->getSourceDataset())->getClusters();
 
         QImage discreteColorMapImage(static_cast<std::int32_t>(clusters.size()), 1, QImage::Format::Format_RGB32);
 

--- a/src/ImageSettingsAction.h
+++ b/src/ImageSettingsAction.h
@@ -98,7 +98,7 @@ public: // Action getters
     ColorMapAction& getColorMap2DAction() { return _colorMap2DAction; }
     OptionAction& getInterpolationTypeAction() { return _interpolationTypeAction; }
     ToggleAction& getUseConstantColorAction() { return _useConstantColorAction; }
-    ToggleAction& getFixChannelRangesToColorSpaceAction() { return _fixChannelRangesToColorSpace; }
+    ToggleAction& getFixChannelRangesToColorSpaceAction() { return _fixChannelRangesToColorSpaceAction; }
     ColorAction& getConstantColorAction() { return _constantColorAction; }
 
 signals:
@@ -113,21 +113,21 @@ signals:
     void channelChanged(ScalarChannelAction& scalarChannelAction);
 
 protected:
-    Layer*                  _layer;                         /** Reference to layer */
-    DecimalAction           _opacityAction;                 /** Opacity action */
-    IntegralAction          _subsampleFactorAction;         /** Subsample factor action */
-    OptionAction            _colorSpaceAction;              /** Color space action */
-    ScalarChannelAction     _scalarChannel1Action;          /** Scalar channel 1 action */
-    ScalarChannelAction     _scalarChannel2Action;          /** Scalar channel 2 action */
-    ScalarChannelAction     _scalarChannel3Action;          /** Scalar channel 3 action */
-    ColorMap1DAction        _colorMap1DAction;              /** One-dimensional color map action */
-    ColorMap2DAction        _colorMap2DAction;              /** Two-dimensional color map action */
-    OptionAction            _interpolationTypeAction;       /** Interpolation type action */
-    ToggleAction            _useConstantColorAction;        /** Constant color action */
-    ToggleAction            _fixChannelRangesToColorSpace;  /** Fixes ranges of channels to color space ranges action */
-    ColorAction             _constantColorAction;           /** Color action */
-    QTimer                  _updateSelectionTimer;          /** Timer to update layer selection when appropriate */
-    QTimer                  _updateScalarDataTimer;         /** Timer to update layer scalar data when appropriate */
+    Layer*                  _layer;                                 /** Reference to layer */
+    DecimalAction           _opacityAction;                         /** Opacity action */
+    IntegralAction          _subsampleFactorAction;                 /** Subsample factor action */
+    OptionAction            _colorSpaceAction;                      /** Color space action */
+    ScalarChannelAction     _scalarChannel1Action;                  /** Scalar channel 1 action */
+    ScalarChannelAction     _scalarChannel2Action;                  /** Scalar channel 2 action */
+    ScalarChannelAction     _scalarChannel3Action;                  /** Scalar channel 3 action */
+    ColorMap1DAction        _colorMap1DAction;                      /** One-dimensional color map action */
+    ColorMap2DAction        _colorMap2DAction;                      /** Two-dimensional color map action */
+    OptionAction            _interpolationTypeAction;               /** Interpolation type action */
+    ToggleAction            _useConstantColorAction;                /** Constant color action */
+    ToggleAction            _fixChannelRangesToColorSpaceAction;    /** Fixes ranges of channels to color space ranges action */
+    ColorAction             _constantColorAction;                   /** Color action */
+    QTimer                  _updateSelectionTimer;                  /** Timer to update layer selection when appropriate */
+    QTimer                  _updateScalarDataTimer;                 /** Timer to update layer scalar data when appropriate */
 
     static const std::int32_t LAZY_UPDATE_INTERVAL = 0;
 };

--- a/src/ImageSettingsAction.h
+++ b/src/ImageSettingsAction.h
@@ -98,6 +98,7 @@ public: // Action getters
     ColorMapAction& getColorMap2DAction() { return _colorMap2DAction; }
     OptionAction& getInterpolationTypeAction() { return _interpolationTypeAction; }
     ToggleAction& getUseConstantColorAction() { return _useConstantColorAction; }
+    ToggleAction& getFixChannelRangesToColorSpaceAction() { return _fixChannelRangesToColorSpace; }
     ColorAction& getConstantColorAction() { return _constantColorAction; }
 
 signals:
@@ -123,6 +124,7 @@ protected:
     ColorMap2DAction        _colorMap2DAction;              /** Two-dimensional color map action */
     OptionAction            _interpolationTypeAction;       /** Interpolation type action */
     ToggleAction            _useConstantColorAction;        /** Constant color action */
+    ToggleAction            _fixChannelRangesToColorSpace;  /** Fixes ranges of channels to color space ranges action */
     ColorAction             _constantColorAction;           /** Color action */
     QTimer                  _updateSelectionTimer;          /** Timer to update layer selection when appropriate */
     QTimer                  _updateScalarDataTimer;         /** Timer to update layer scalar data when appropriate */

--- a/src/ScalarChannelAction.h
+++ b/src/ScalarChannelAction.h
@@ -59,6 +59,9 @@ public:
     /** Get image size */
     QSize getImageSize();
 
+    /** Set fixed displayRange */
+    void setColorSpaceRange(bool status, float lower = -1, float upper = -1);
+
 public: // Channel data
 
     /** Get scalar data */
@@ -126,6 +129,8 @@ private:
     WindowLevelAction       _windowLevelAction;     /** Window/level action */
     QVector<float>          _scalarData;            /** Channel scalar data for the specified dimension */
     QPair<float, float>     _scalarDataRange;       /** Scalar data range */
+    QPair<float, float>     _colorSpaceRange;       /** Color Space range */
+    bool                    _useColorSpaceRange;    /** _scalarDataRange is ignored and instead a color space dependend range is used */
 
     friend class ImageAction;
 };


### PR DESCRIPTION
Currently, color images are not displayed correctly since the image dimensions min and max values are used to define the channel range, leading to to false color. (See https://github.com/ManiVaultStudio/ImageViewerPlugin/issues/101 for example screenshots.)

This PR adds the option `Set channel ranges to color space` which is only enabled for 3-channel color mapping:
- For RGB: all channel ranges are set to [0, 255]
- For HSL and LAB the range depends on the channel (e.g. hue in [0, 360] and saturation in [0, 1])

The option is `OFF` by default, i.e. no change in behavior if not explicitly requested.

Fixes https://github.com/ManiVaultStudio/ImageViewerPlugin/issues/101