### PR TITLE
Update mask data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ endif(MSVC)
 find_package(OpenGL REQUIRED)
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets OpenGL OpenGLWidgets REQUIRED)
 find_package(ManiVault COMPONENTS Core PointData ClusterData ImageData CONFIG QUIET)
-find_package(OpenMP)
 
 # -----------------------------------------------------------------------------
 # Source files

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -193,11 +193,17 @@ void Layer::initialize(ImageViewerPlugin* imageViewerPlugin, const mv::Dataset<I
         getRenderer()->setAnimationEnabled(animationEnabled);
     });
 
-    _imagesDataset->getMaskData(_maskData);
+    auto updateMaskData = [this]() {
+        _imagesDataset->getMaskData(_maskData);
 
-    // Apply masking to props
-    this->getPropByName<ImageProp>("ImageProp")->setMaskData(_maskData);
-    this->getPropByName<SelectionProp>("SelectionProp")->setMaskData(_maskData);
+        // Apply masking to props
+        this->getPropByName<ImageProp>("ImageProp")->setMaskData(_maskData);
+        this->getPropByName<SelectionProp>("SelectionProp")->setMaskData(_maskData);
+        };
+
+    connect(&_imagesDataset, &Dataset<Images>::dataChanged, this, updateMaskData);
+
+    updateMaskData();
 }
 
 Layer::~Layer()


### PR DESCRIPTION
Currently, the image mask (transparency) is only read when an image is first loaded. 
But the image mask might be changed later, which should be reflected in the image viewer.

Drive-by:
- OpenMP is not used, not even linked to. No need to look for it then.