### PR TITLE
Fix duo channel ranges

### DIFF
--- a/src/ImageSettingsAction.cpp
+++ b/src/ImageSettingsAction.cpp
@@ -94,7 +94,7 @@ ImageSettingsAction::ImageSettingsAction(QObject* parent, const QString& title) 
 	            case ColorSpaceType::HSL: {
 	                _scalarChannel1Action.setColorSpaceRange(true, 0, 360); // hue
 	                _scalarChannel2Action.setColorSpaceRange(true, 0, 1);   // saturation
-	                _scalarChannel3Action.setColorSpaceRange(true, 0, 1);   // value
+	                _scalarChannel3Action.setColorSpaceRange(true, 0, 1);   // lightness
 	                break;
 	            }
 

--- a/src/ImageSettingsAction.cpp
+++ b/src/ImageSettingsAction.cpp
@@ -372,7 +372,7 @@ void ImageSettingsAction::colorSpaceChanged()
             _colorMap1DAction.setEnabled(false);
             _colorMap2DAction.setEnabled(!_useConstantColorAction.isChecked());
 
-            _fixChannelRangesToColorSpaceAction.setChecked(false);
+            _fixChannelRangesToColorSpaceAction.setChecked(true);
             _fixChannelRangesToColorSpaceAction.setEnabled(false);
 
             break;

--- a/src/ImageSettingsAction.cpp
+++ b/src/ImageSettingsAction.cpp
@@ -77,7 +77,14 @@ ImageSettingsAction::ImageSettingsAction(QObject* parent, const QString& title) 
 
             // only set color space range for RGB, HSL and LAB
             switch (static_cast<ColorSpaceType>(_colorSpaceAction.getCurrentIndex())) {
-	            case ColorSpaceType::RGB: {
+                case ColorSpaceType::Duo: {
+                    _scalarChannel1Action.setColorSpaceRange(true, 0, 255); // red
+                    _scalarChannel2Action.setColorSpaceRange(true, 0, 255); // green
+                    _scalarChannel3Action.setColorSpaceRange(true, 0, 255); // blue
+                    break;
+                }
+            
+                case ColorSpaceType::RGB: {
 	                _scalarChannel1Action.setColorSpaceRange(true, 0, 255); // red
 	                _scalarChannel2Action.setColorSpaceRange(true, 0, 255); // green
 	                _scalarChannel3Action.setColorSpaceRange(true, 0, 255); // blue


### PR DESCRIPTION
Follow up to https://github.com/ManiVaultStudio/ImageViewerPlugin/pull/136.

I see small color differences for the same data values when recolored with a 2D colormap in the Image Viewer compared to the Scatterplot. Adjusting the color space range fixes this: The 2D colormaps use RGB colors AFAIK, so it should behave the same way as the 3 channel mode with RGB colors.