### PR TITLE
Mirror image to align QImage and OpenGL texture coordinates

### DIFF
--- a/src/ImageProp.cpp
+++ b/src/ImageProp.cpp
@@ -244,7 +244,7 @@ void ImageProp::setColorMapImage(const QImage& colorMapImage)
             auto& texture = getTextureByName("ColorMap");
 
             // Reset and assign the texture
-            texture.reset(new QOpenGLTexture(colorMapImage));
+            texture.reset(new QOpenGLTexture(colorMapImage.mirrored()));
 
             // Create the texture if not created
             if (!texture->isCreated())


### PR DESCRIPTION
In `ImageProp::setColorMapImage` we use
```cpp
texture.reset(new QOpenGLTexture(colorMapImage));
```

Qt's docs on [QOpenGLTexture](https://doc.qt.io/qt-6/qopengltexture.html#QOpenGLTexture-1) suggest:
```cpp
QOpenGLTexture *texture = new QOpenGLTexture(QImage(fileName).flipped());
```
> Note that the QImage is flipped vertically to account for the fact that OpenGL and QImage use opposite directions for the y axis. Another option would be to transform your texture coordinates.

Currently this yields a different re-coloring in the ImageViewer vs the Scatterplot for the same data:
<img width="1911" height="1152" alt="image" src="https://github.com/user-attachments/assets/07a3d225-d8b1-4f81-ad62-c29549625481" />

The data here is a 2D image where each pixel value is its coordinates, i.e. at (x: 0, y: 0) the value is (1: 0, 2: 0) and at  (x: 25, y: 50) the value is (1: 25, 2: 50) 
<img width="401" height="273" alt="image" src="https://github.com/user-attachments/assets/f7de0003-48ca-4640-8983-19bfe828a788" />

When mirroring the texture image we get consistent behavior:

<img width="1890" height="1106" alt="image" src="https://github.com/user-attachments/assets/e93f5548-b28b-496c-b3e6-1793a91a7a2e" />

In the scatterplot we use `Texture2D::loadFromImage` from the core (Texture.h) via the PointRenderer.
There we just use `(QRgb*)image.bits()` to point to the color values instead of converting a QImage to QOpenGLTexture, which appears to behave differently.