### PR TITLE
makes sure image quad is drawn in correct context.

### DIFF
--- a/src/QuadShape.cpp
+++ b/src/QuadShape.cpp
@@ -3,6 +3,7 @@
 #include "LayersRenderer.h"
 
 #include <QDebug>
+#include <QOpenGLFunctions>
 
 std::uint32_t QuadShape::_vertexAttribute = 0;
 std::uint32_t QuadShape::_textureAttribute = 1;
@@ -46,16 +47,11 @@ void QuadShape::render()
     if (!canRender())
         return;
 
-    auto& renderer = _prop.getRenderer();
-
-    renderer.bindOpenGLContext();
+    _vao.bind();
     {
-        _vao.bind();
-        {
-            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
-        }
-        _vao.release();
+        _prop.getRenderer().getOpenGLContext()->functions()->glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
     }
+    _vao.release();
 }
 
 QRectF QuadShape::getRectangle() const


### PR DESCRIPTION
In some cases (e.g., certain macOS configurations) the previous code would just render a blank image. The updated code should make sure the image is drawn in the correct context.

I do not expect this to lead to regression on other platforms, but please test on Windows/Linux