### PR TITLE
Fix build after serialization api update

### DIFF
--- a/src/ImageProp.cpp
+++ b/src/ImageProp.cpp
@@ -185,8 +185,8 @@ QRectF ImageProp::getWorldBoundingRectangle() const
     const auto matrix = _renderable.getModelMatrix() * getModelMatrix();
 
     // Compute rectangle extents in world coordinates
-    const auto worldTopLeft     = matrix * boundingRectangle.topLeft();
-    const auto worldBottomRight = matrix * boundingRectangle.bottomRight();
+    const auto worldTopLeft     = matrix.map(boundingRectangle.topLeft());
+    const auto worldBottomRight = matrix.map(boundingRectangle.bottomRight());
 
     const auto rectangleFromPoints = [](const QPointF& first, const QPointF& second) -> QRectF {
         QRectF rectangle;

--- a/src/ImageViewerPlugin.cpp
+++ b/src/ImageViewerPlugin.cpp
@@ -275,8 +275,8 @@ void ImageViewerPlugin::arrangeLayers(LayersLayout layersLayout)
             columnWidths.resize(numberOfColumns, 0.0f);
             rowHeights.resize(numberOfRows, 0.0f);
 
-            for (int columnIndex = 0; columnIndex < numberOfColumns; ++columnIndex) {
-                for (int rowIndex = 0; rowIndex < numberOfRows; ++rowIndex) {
+            for (std::uint32_t columnIndex = 0; columnIndex < numberOfColumns; ++columnIndex) {
+                for (std::uint32_t rowIndex = 0; rowIndex < numberOfRows; ++rowIndex) {
                     auto layer = layers[rowIndex * numberOfColumns + columnIndex];
                     
                     const auto layerWidth = layer->getWorldBoundingRectangle().width();
@@ -286,8 +286,8 @@ void ImageViewerPlugin::arrangeLayers(LayersLayout layersLayout)
                 }
             }
 
-            for (int rowIndex = 0; rowIndex < numberOfRows; ++rowIndex) {
-                for (int columnIndex = 0; columnIndex < numberOfColumns; ++columnIndex) {
+            for (std::uint32_t rowIndex = 0; rowIndex < numberOfRows; ++rowIndex) {
+                for (std::uint32_t columnIndex = 0; columnIndex < numberOfColumns; ++columnIndex) {
                     auto layer = layers[rowIndex * numberOfColumns + columnIndex];
 
                     const auto layerHeight = layer->getWorldBoundingRectangle().height();

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -8,6 +8,7 @@
 #include "LayersRenderer.h"
 
 #include <util/Exception.h>
+#include <util/Serialization.h>
 #include <PointData/PointData.h>
 #include <ClusterData/ClusterData.h>
 

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -338,8 +338,8 @@ QRectF Layer::getWorldBoundingRectangle() const
     // Compute composite matrix and rectangle extents in world coordinates
     const auto matrix           = getModelMatrix() * getPropByName<ImageProp>("ImageProp")->getModelMatrix();
     const auto visibleRectangle = QRectF(_imagesDataset->getVisibleRectangle());
-    const auto worldTopLeft     = matrix * visibleRectangle.topLeft();
-    const auto worldBottomRight = matrix * visibleRectangle.bottomRight();
+    const auto worldTopLeft     = matrix.map(visibleRectangle.topLeft());
+    const auto worldBottomRight = matrix.map(visibleRectangle.bottomRight());
 
     //qDebug() << _imagesDataset->getGuiName() << visibleRectangle;
 
@@ -1032,7 +1032,8 @@ QRectF Layer::getWorldSelectionRectangle() const
     const auto matrix = getModelMatrix() * layerImageProp->getModelMatrix();
 
     // Compute rectangle extents in world coordinates
-    return QRectF(matrix * QPointF(_imageSelectionRectangle.topLeft()), matrix * QPointF(_imageSelectionRectangle.bottomRight()));
+    return { matrix.map(QPointF(_imageSelectionRectangle.topLeft())),
+            matrix.map(QPointF(_imageSelectionRectangle.bottomRight())) };
 }
 
 void Layer::zoomToExtents()

--- a/src/LayersModel.cpp
+++ b/src/LayersModel.cpp
@@ -1,12 +1,13 @@
 #include "LayersModel.h"
 #include "ImageViewerPlugin.h"
 
-#include <Application.h>
 #include <CoreInterface.h>
 #include <DataHierarchyItem.h>
-#include <util/Exception.h>
+
 #include <event/Event.h>
+#include <util/Exception.h>
 #include <util/Serialization.h>
+
 #include <PointData/PointData.h>
 
 #include <QMessageBox>

--- a/src/LayersModel.cpp
+++ b/src/LayersModel.cpp
@@ -6,6 +6,7 @@
 #include <DataHierarchyItem.h>
 #include <util/Exception.h>
 #include <event/Event.h>
+#include <util/Serialization.h>
 #include <PointData/PointData.h>
 
 #include <QMessageBox>


### PR DESCRIPTION
After https://github.com/ManiVaultStudio/core/pull/1229 we need to add some includes.

Also:
- use `.map()` instead of `*` for multiplying a QMatrix4x4 with a QPoint since that is deprecated: https://doc.qt.io/qt-6/qmatrix4x4-obsolete.html